### PR TITLE
feat: add additional checked_ support for u128

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod lbp;
 pub mod liquidity_mining;
 pub mod omnipool;
 pub mod stableswap;
+pub mod support;
 #[cfg(test)]
 pub mod test_utils;
 pub mod transcendental;

--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -1,0 +1,2 @@
+mod u128;
+pub mod traits;

--- a/src/support/traits.rs
+++ b/src/support/traits.rs
@@ -1,0 +1,32 @@
+pub trait CheckedAddInto {
+    type Output;
+    fn checked_add_into(&self, other: &Self) -> Option<Self::Output>;
+}
+
+pub trait CheckedMulInto {
+    type Output;
+    fn checked_mul_into(&self, other: &Self) -> Option<Self::Output>;
+}
+
+pub trait Convert {
+    type Inner;
+
+    fn try_to_inner(&self) -> Option<Self::Inner>;
+    fn fit_to_inner(&self) -> Self::Inner;
+    fn from_inner(s: &Self::Inner) -> Self;
+}
+
+pub trait CheckedAddInner: Sized {
+    type Inner;
+    fn checked_add_inner(&self, other: &Self::Inner) -> Option<Self>;
+}
+
+pub trait CheckedMulInner: Sized {
+    type Inner;
+    fn checked_mul_inner(&self, other: &Self::Inner) -> Option<Self>;
+}
+
+pub trait CheckedDivInner: Sized {
+    type Inner;
+    fn checked_div_inner(&self, other: &Self::Inner) -> Option<Self>;
+}

--- a/src/support/u128.rs
+++ b/src/support/u128.rs
@@ -1,0 +1,80 @@
+use crate::support::traits::{CheckedAddInto, CheckedDivInner, CheckedMulInner, CheckedMulInto, Convert};
+use primitive_types::U256;
+
+impl CheckedAddInto for u128 {
+    type Output = U256;
+
+    fn checked_add_into(&self, other: &Self) -> Option<Self::Output> {
+        let s = Self::Output::from(*self);
+        let o = Self::Output::from(*other);
+        s.checked_add(o)
+    }
+}
+
+impl CheckedMulInto for u128 {
+    type Output = U256;
+
+    fn checked_mul_into(&self, other: &Self) -> Option<Self::Output> {
+        let s = Self::Output::from(*self);
+        let o = Self::Output::from(*other);
+        s.checked_mul(o)
+    }
+}
+
+impl Convert for U256 {
+    type Inner = u128;
+
+    fn try_to_inner(&self) -> Option<Self::Inner> {
+        Self::Inner::try_from(*self).ok()
+    }
+
+    fn fit_to_inner(&self) -> Self::Inner {
+        let shift = self.bits().saturating_sub(128);
+        (self >> shift).low_u128()
+    }
+
+    fn from_inner(s: &Self::Inner) -> Self {
+        Self::from(*s)
+    }
+}
+
+impl CheckedDivInner for U256 {
+    type Inner = u128;
+
+    fn checked_div_inner(&self, other: &Self::Inner) -> Option<Self> {
+        self.checked_div(Self::from_inner(other))
+    }
+}
+
+impl CheckedMulInner for U256 {
+    type Inner = u128;
+
+    fn checked_mul_inner(&self, other: &Self::Inner) -> Option<Self> {
+        self.checked_mul(Self::from_inner(other))
+    }
+}
+
+#[test]
+fn checked_add_into_works_for_u128() {
+    let r = 100u128;
+    let result = r.checked_add_into(&200u128).unwrap();
+    assert_eq!(result, U256::from(300u128));
+}
+
+#[test]
+fn checked_mul_into_works_for_u128() {
+    let r = 100u128;
+    let result = r.checked_mul_into(&200u128).unwrap();
+    assert_eq!(result, U256::from(20000u128));
+}
+
+#[test]
+fn convert_should_work_for_u256() {
+    let p = u128::MAX.checked_mul_into(&u128::MAX).unwrap().fit_to_inner();
+    assert_eq!(p, 340282366920938463463374607431768211454);
+
+    let p = 100u128.checked_mul_into(&100u128).unwrap().fit_to_inner();
+    assert_eq!(p, 10000);
+
+    assert_eq!(U256::from_inner(&100u128), U256::from(100u32));
+}


### PR DESCRIPTION
This PR introduces few additional trait to enhance u128 and U256 types.

These 2 types are heaviliy used across all math calculations.

It almost always involves converting u128 to U256, performing a calculation, and then converting it back to u128. 

it was always necessary to write code that converts it to and back between these types and figuring out the logic wherever it was needed.

This enhances the u128 and U256 as follows:

instead of doing:

```
let num, other_num, divider = to_u256!(some_u128_num, some_other_u128_num, divider_u128);

let result = num.checked_mul(&other_num)?.checked_div(&divider)?;

let result_u128 = u128::try_from(&result)?;
```

you can do just this:

`let result = some_num.checked_mul_into(&other_num)?.checked_div_inner(&divider).try_to_inner()?;`

or if you just want to fit it:

`let result = some_num.checked_mul_into(&other_num)?.fit_to_inner();`

it is also possible to continue using not yet converted u128,eg.

`let result = some_num.checked_mul_into(&other_num)?.checked_div_inner(&another_128_num)?.fit_to_inner();`