### PR TITLE
feat: calculate_rewards_for_periods() for liquidity mining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hydra-dx-math"
-version = "5.1.3"
+version = "5.1.4"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = 'Apache-2.0'
 name = "hydra-dx-math"
 description = "A collection of utilities to make performing liquidity pool calculations more convenient."
 repository = 'https://github.com/galacticcouncil/hydradx-math'
-version = "5.1.3"
+version = "5.1.4"
 
 [dependencies]
 primitive-types = {default-features = false, version = '0.12.0'}

--- a/src/liquidity_mining/liquidity_mining.rs
+++ b/src/liquidity_mining/liquidity_mining.rs
@@ -118,3 +118,12 @@ pub fn calculate_reward(
 pub fn calculate_adjusted_shares(shares: Balance, price_adjustment: FixedU128) -> Result<Balance, MathError> {
     price_adjustment.checked_mul_int(shares).ok_or(MathError::Overflow)
 }
+
+/// This function calculates rewards [`Balance`] for number of periods or error.
+pub fn calculate_rewards_for_periods<Period: num_traits::CheckedSub + TryInto<u32> + TryInto<u128>>(
+    reward_per_period: FixedU128,
+    periods_since_last_update: Period,
+) -> Result<Balance, MathError> {
+    let periods = TryInto::<u128>::try_into(periods_since_last_update).map_err(|_e| MathError::Overflow)?;
+    reward_per_period.checked_mul_int(periods).ok_or(MathError::Overflow)
+}

--- a/src/liquidity_mining/tests.rs
+++ b/src/liquidity_mining/tests.rs
@@ -732,3 +732,23 @@ fn calculate_adjusted_shares_should_work() {
         313_948_636_755_764
     );
 }
+
+#[test]
+fn calculate_rewards_for_periods_should_work() {
+    assert_eq!(calculate_rewards_for_periods(FixedU128::from(0), 0).unwrap(), 0);
+
+    assert_eq!(
+        calculate_rewards_for_periods(FixedU128::from(0), 16_841_351,).unwrap(),
+        0
+    );
+
+    assert_eq!(
+        calculate_rewards_for_periods(FixedU128::from_inner(156_874_561_300_000_000), 16_841_351,).unwrap(),
+        2_641_979
+    );
+
+    assert_eq!(
+        calculate_rewards_for_periods(FixedU128::from_inner(18_641_535_156_874_561_300_000_000), 16_841_351,).unwrap(),
+        313_948_636_755_764
+    );
+}


### PR DESCRIPTION
Added `calculate_rewards_foer_periods()` to liquidity-mining.